### PR TITLE
Make Tab a *local* shortcut

### DIFF
--- a/main-process/playAndPauseVideo.js
+++ b/main-process/playAndPauseVideo.js
@@ -1,10 +1,8 @@
-const { globalShortcut } = require('electron')
 const { ipcRenderer } = require('electron')
-
 const toggleMessage = 'User has toggled Play/Pause'
 
-const registerPlayPauseToggleAsGlobalShortcut = function (appWindow) {
-  globalShortcut.register('Tab', function () {
+const registerPlayPauseToggleAsGlobalShortcut = function (appWindow, shortcutRegistrationFunction) {
+  shortcutRegistrationFunction(appWindow, 'Tab', function () {
     if (appWindow.isFocused()) {
       appWindow.webContents.send(toggleMessage)
     }
@@ -18,8 +16,6 @@ const handlePlayPauseToggle = function (player) {
     } else {
       player.play()
     }
-    event.sender.send('gotcha!')
-    console.log(player)
   })
 }
 

--- a/main.js
+++ b/main.js
@@ -1,10 +1,12 @@
-let { app, BrowserWindow, globalShortcut, Menu } = require('electron')
+let { app, BrowserWindow, Menu } = require('electron')
+const localShortcut = require('electron-localshortcut')
 const fs = require('fs-plus')
 const ipc = require('electron').ipcMain
 const { saveFile } = require('./saveTranscript')
 const { showUnsavedChangesDialog } = require('./closeTheApp')
 const menuTemplate = require('./menu/menuTemplate')
 const { registerPlayPauseToggleAsGlobalShortcut } = require('./main-process/playAndPauseVideo')
+const electronLocalShortcut = require('electron-localshortcut')
 
 let mainWindow
 
@@ -19,7 +21,7 @@ function createWindow () {
   })
 
   app.on('will-quit', function () {
-    globalShortcut.unregisterAll()
+    localShortcut.unregisterAll(mainWindow)
   })
 
   mainWindow.loadURL(`file://${__dirname}/index.html`)
@@ -37,7 +39,7 @@ function createWindow () {
 
 app.on('ready', () => {
   createWindow()
-  registerPlayPauseToggleAsGlobalShortcut(mainWindow)
+  registerPlayPauseToggleAsGlobalShortcut(mainWindow, electronLocalShortcut.register)
 
   mainWindow.once('ready-to-show', () => {
     const menu = Menu.buildFromTemplate(menuTemplate)

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   },
   "homepage": "https://github.com/briandk/transcriptase#readme",
   "dependencies": {
+    "electron-localshortcut": "^2.0.2",
     "font-awesome": "^4.7.0",
     "fs-plus": "^3.0.0",
     "jquery": "^3.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -823,6 +823,17 @@ electron-download@^4.1.0:
     semver "^5.3.0"
     sumchecker "^2.0.1"
 
+electron-is-accelerator@^0.1.0:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/electron-is-accelerator/-/electron-is-accelerator-0.1.2.tgz#509e510c26a56b55e17f863a4b04e111846ab27b"
+
+electron-localshortcut@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/electron-localshortcut/-/electron-localshortcut-2.0.2.tgz#6a1adcd6514c957328ec7912f5ccb5e1c10706db"
+  dependencies:
+    debug "^2.6.8"
+    electron-is-accelerator "^0.1.0"
+
 electron-osx-sign@0.4.7:
   version "0.4.7"
   resolved "https://registry.yarnpkg.com/electron-osx-sign/-/electron-osx-sign-0.4.7.tgz#1d75647a82748eacd48bea70616ec83ffade3ee5"


### PR DESCRIPTION
Instead of a global one. When tab was global, you couldn't use the tab key at all in other programs (say, to autocomplete in a Terminal or add a literal tab in a text editor).

Fixes #52