### PR TITLE
Use css grid for layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
   },
   "dependencies": {
     "@types/quill": "^1.3.6",
+    "babel-core": "^6.26.3",
     "electron-is-dev": "^0.3.0",
     "electron-log": "^2.2.13",
     "electron-store": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,6 @@
     "react": "^16.3.2",
     "react-dom": "^16.2.0",
     "react-transition-group": "^2.2.1",
-    "uikit": "^3.0.0-rc.4",
     "video.js": "^7.0.2"
   },
   "devDependencies": {

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -49,6 +49,6 @@ document.addEventListener("drop", event => event.preventDefault())
 import "../styles/uikit.css"
 
 ReactDOM.render(<RootComponent />, document.getElementById("root"), () => {
-  createVideoPlayer()
+  // createVideoPlayer()
   createTranscriptEditor()
 })

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -49,6 +49,6 @@ document.addEventListener("drop", event => event.preventDefault())
 import "../styles/uikit.css"
 
 ReactDOM.render(<RootComponent />, document.getElementById("root"), () => {
-  // createVideoPlayer()
+  createVideoPlayer()
   createTranscriptEditor()
 })

--- a/src/app/root-component.tsx
+++ b/src/app/root-component.tsx
@@ -4,12 +4,15 @@ import { compose } from "glamor"
 import { styles, colors } from "../views/theme"
 import { AppLayout } from "../views/app-layout/app-layout"
 
-const ROOT = compose(styles.fullScreen, {
-  background: colors.window.background,
-  "& ::-webkit-scrollbar": { backgroundColor: colors.scrollbar.base, width: 12, height: 12 },
-  "& ::-webkit-scrollbar-track": { backgroundColor: colors.scrollbar.track },
-  "& ::-webkit-scrollbar-thumb": { backgroundColor: colors.scrollbar.thumb, borderRadius: 4 },
-})
+const ROOT = compose(
+  styles.fullScreen,
+  {
+    background: colors.window.background,
+    "& ::-webkit-scrollbar": { backgroundColor: colors.scrollbar.base, width: 12, height: 12 },
+    "& ::-webkit-scrollbar-track": { backgroundColor: colors.scrollbar.track },
+    "& ::-webkit-scrollbar-thumb": { backgroundColor: colors.scrollbar.thumb, borderRadius: 4 },
+  },
+)
 
 export class RootComponent extends React.Component<{}, {}> {
   render() {

--- a/src/styles/app-layout-grid.css
+++ b/src/styles/app-layout-grid.css
@@ -1,0 +1,7 @@
+/* Three columns: 100px each */
+.grid-container {
+    display: grid;
+    grid-template-columns: 600px 600px;
+    grid-template-rows: 600px;
+    grid-gap: 1rem;
+}

--- a/src/views/app-layout/app-layout.tsx
+++ b/src/views/app-layout/app-layout.tsx
@@ -9,12 +9,10 @@ class AppLayout extends React.Component<{}, AppLayoutState> {
   public render() {
     return (
       <div className="grid-container">
-        {/*<div id="video-player-container" className="item item1 video-player-container">*/}
-        {/*/!*<video id="video-player" className="video-js">*!/*/}
-        {/*/!*<source />*!/*/}
-        {/*/!*</video>*!/*/}
-        <div className={"item"}>
-          <h1>Hello, World!</h1>
+        <div id="video-player-container" className="item item1 video-player-container">
+          <video id="video-player" className="video-js">
+            <source />
+          </video>
         </div>
         <div className={"item"}>
           <h1>I am Mickey Mouse!</h1>

--- a/src/views/app-layout/app-layout.tsx
+++ b/src/views/app-layout/app-layout.tsx
@@ -1,4 +1,5 @@
 import * as React from "react"
+import "../../styles/app-layout-grid.css"
 
 interface AppLayoutState {}
 
@@ -7,24 +8,26 @@ class AppLayout extends React.Component<{}, AppLayoutState> {
 
   public render() {
     return (
-      <div id="content" className="uk-margin-top uk-margin-left uk-margin-right uk-container">
-        <div className="uk-grid">
-          <div id="video-player-container" className="video-player-container uk-width-1-2">
-            <video id="video-player" className="video-js">
-              <source />
-            </video>
-          </div>
-          <div className="uk-width-1-2 transcript-column">
-            <div className="editor-container" data-last-saved-path="">
-              <div id="toolbar">
-                {/* <button id="timestamp-button">
-                  <span className="fa fa-clock-o fa-2x" />
-                </button> */}
-              </div>
-              <div className="transcript-editor" />
-            </div>
-          </div>
+      <div className="grid-container">
+        {/*<div id="video-player-container" className="item item1 video-player-container">*/}
+        {/*/!*<video id="video-player" className="video-js">*!/*/}
+        {/*/!*<source />*!/*/}
+        {/*/!*</video>*!/*/}
+        <div className={"item"}>
+          <h1>Hello, World!</h1>
         </div>
+        <div className={"item"}>
+          <h1>I am Mickey Mouse!</h1>
+        </div>
+        {/*</div>*/}
+        {/*<div className="item item2 editor-container" data-last-saved-path="">*/}
+        {/*<div id="toolbar">*/}
+        {/*/!* <button id="timestamp-button">*/}
+        {/*<span className="fa fa-clock-o fa-2x" />*/}
+        {/*</button> *!/*/}
+        {/*</div>*/}
+        {/*<div className="transcript-editor" />*/}
+        {/*</div>*/}
       </div>
     )
   }

--- a/src/views/app-layout/app-layout.tsx
+++ b/src/views/app-layout/app-layout.tsx
@@ -14,14 +14,11 @@ class AppLayout extends React.Component<{}, AppLayoutState> {
             <source />
           </video>
         </div>
-        {/*<div className={"item"}>*/}
-        {/*<h1>I am Mickey Mouse!</h1>*/}
-        {/*</div>*/}
         <div className="item item2 editor-container" data-last-saved-path="">
           <div id="toolbar">
-            {/* <button id="timestamp-button">
-        <span className="fa fa-clock-o fa-2x" />
-        </button> */}
+            {/*<button id="timestamp-button">*/}
+            {/*<span className="fa fa-clock-o fa-2x" />*/}
+            {/*</button>*/}
           </div>
           <div className="transcript-editor" />
         </div>

--- a/src/views/app-layout/app-layout.tsx
+++ b/src/views/app-layout/app-layout.tsx
@@ -14,18 +14,17 @@ class AppLayout extends React.Component<{}, AppLayoutState> {
             <source />
           </video>
         </div>
-        <div className={"item"}>
-          <h1>I am Mickey Mouse!</h1>
+        {/*<div className={"item"}>*/}
+        {/*<h1>I am Mickey Mouse!</h1>*/}
+        {/*</div>*/}
+        <div className="item item2 editor-container" data-last-saved-path="">
+          <div id="toolbar">
+            {/* <button id="timestamp-button">
+        <span className="fa fa-clock-o fa-2x" />
+        </button> */}
+          </div>
+          <div className="transcript-editor" />
         </div>
-        {/*</div>*/}
-        {/*<div className="item item2 editor-container" data-last-saved-path="">*/}
-        {/*<div id="toolbar">*/}
-        {/*/!* <button id="timestamp-button">*/}
-        {/*<span className="fa fa-clock-o fa-2x" />*/}
-        {/*</button> *!/*/}
-        {/*</div>*/}
-        {/*<div className="transcript-editor" />*/}
-        {/*</div>*/}
       </div>
     )
   }

--- a/src/views/shared/scrollable-content/scrollable-content.tsx
+++ b/src/views/shared/scrollable-content/scrollable-content.tsx
@@ -15,5 +15,14 @@ const ROOT = compose(
 )
 
 export function ScrollableContent(props: ScrollableContentProps) {
-  return <div {...compose(ROOT, props.style)}>{props.children}</div>
+  return (
+    <div
+      {...compose(
+        ROOT,
+        props.style,
+      )}
+    >
+      {props.children}
+    </div>
+  )
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9085,10 +9085,6 @@ uglifyjs-webpack-plugin@^1.2.4:
     webpack-sources "^1.1.0"
     worker-farm "^1.5.2"
 
-uikit@^3.0.0-rc.4:
-  version "3.0.0-rc.4"
-  resolved "https://registry.yarnpkg.com/uikit/-/uikit-3.0.0-rc.4.tgz#a2011adf35d195ddc6be3ac4e0674b2feda4a756"
-
 ultron@1.0.x:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.0.2.tgz#ace116ab557cd197386a4e88f4685378c8b2e4fa"


### PR DESCRIPTION
## What things were like before this PR

We used [uikit](https://getuikit.com) to handle [grid](https://getuikit.com/docs/grid#usage) stuff

## What this PR changes

In trying to reduce dependencies, we now use [CSS Grid Layout](https://mozilladevelopers.github.io/playground/css-grid/02-first-grid/), which is supported in the browser. Because grid support is built-in, we can pretty safely remove `uikit` as a dependency. For now, anyway.