### PR TITLE
Refactor save before closing

### DIFF
--- a/src/common/appState.ts
+++ b/src/common/appState.ts
@@ -1,0 +1,13 @@
+export interface AppState {
+  transcript: string
+}
+
+let appState: AppState = { transcript: "" }
+
+export const setAppState = (state: AppState) => {
+  appState = state
+}
+
+export const getAppState = () => {
+  return appState
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -39,8 +39,6 @@ let mainWindow: BrowserWindow = null
  * @return The main BrowserWindow.
  */
 export function createMainWindow() {
-  console.log("creating main window!")
-
   // create our main window
   const window = new BrowserWindow({
     width: 1200,
@@ -58,7 +56,7 @@ export function createMainWindow() {
       backgroundThrottling: true,
       nodeIntegration: true,
       textAreasAreResizable: false,
-      webSecurity: true,
+      webSecurity: false,
     },
   })
   if (isDevelopment) {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -6,12 +6,30 @@ import { setContentSecurityPolicy } from "../renderer/contentSecurityPolicy"
 import { editorIsDirty, listenForWhenTheEditorIsDirty, registerSaveHandler } from "./saveFile"
 import { saveBeforeClosing } from "./saveBeforeClosing"
 import { listenForKeyboardShortcutToCloseTheWindow } from "./listenForKeyboardShortcut"
+import installExtension, {
+  REACT_DEVELOPER_TOOLS,
+  REDUX_DEVTOOLS,
+} from "electron-devtools-installer"
 
 const isDevelopment = process.env.NODE_ENV !== "production"
+const installDevTools: (isDev: boolean) => void = (isDev: boolean) => {
+  const tools: any[] = [REACT_DEVELOPER_TOOLS, REDUX_DEVTOOLS]
+  if (isDev) {
+    require("devtron").install()
+  }
+
+  tools.map(devTool =>
+    installExtension(devTool)
+      .then(name => console.log(`Added Extension:  ${name}`))
+      .catch(err => console.log("An error occurred: ", err)),
+  )
+
+  installExtension(REDUX_DEVTOOLS)
+}
+
 let mainWindow: BrowserWindow = null
 
 // default dimensions
-export const DIMENSIONS = { width: 1000, height: 800, minWidth: 450, minHeight: 450 }
 
 /**
  * Creates the main window.
@@ -103,5 +121,6 @@ app.on("ready", () => {
     }
   })
   listenForKeyboardShortcutToCloseTheWindow(mainWindow)
+  installDevTools(isDevelopment)
   mainWindow.show()
 })

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -3,7 +3,7 @@ import path from "path"
 import { format as formatUrl } from "url"
 import { createMenu } from "./menu"
 import { setContentSecurityPolicy } from "../renderer/contentSecurityPolicy"
-import { editorIsDirty, listenForWhenTheEditorIsDirty, registerSaveHandler } from "./saveFile"
+import { editorIsDirty, listenForWhenTheEditorChanges } from "./saveFile"
 import { saveBeforeClosing } from "./saveBeforeClosing"
 import { listenForKeyboardShortcutToCloseTheWindow } from "./listenForKeyboardShortcut"
 import installExtension, {
@@ -112,8 +112,7 @@ app.on("ready", () => {
   createMenu(mainWindow)
   // isDevelopment ? installDevTools() : null
   setContentSecurityPolicy()
-  registerSaveHandler(mainWindow)
-  listenForWhenTheEditorIsDirty()
+  listenForWhenTheEditorChanges()
   mainWindow.addListener("close", (event: ElectronEvent) => {
     if (editorIsDirty()) {
       event.preventDefault()

--- a/src/main/menu/menu.ts
+++ b/src/main/menu/menu.ts
@@ -2,7 +2,7 @@ import { Menu } from "electron"
 import { createMacMenu } from "./macos-menu"
 import { createLinuxMenu } from "./linux-menu"
 import { createWindowsMenu } from "./windows-menu"
-import { isMac, isLinux, isWindows } from "../../lib/platform/index"
+import { isMac, isLinux, isWindows } from "../../lib/platform"
 
 /**
  * Attaches the menu to the appropriate place.

--- a/src/main/menu/shared-menu.ts
+++ b/src/main/menu/shared-menu.ts
@@ -82,8 +82,10 @@ export const fileOperations: MenuItemConstructorOptions = {
       accelerator: "CmdOrCtrl+T",
       click: (item: MenuItem, window: BrowserWindow, event: Event) => {
         const pathToTranscript = promptUserToSelectFile(window)
-        const transcript = readFileSync(pathToTranscript, { encoding: "utf-8" })
-        window.webContents.send(userHasChosenTranscriptFile, transcript.toString())
+        if (pathToTranscript) {
+          const transcript = readFileSync(pathToTranscript, { encoding: "utf-8" })
+          window.webContents.send(userHasChosenTranscriptFile, transcript.toString())
+        }
       },
     },
     {

--- a/src/main/saveFile.ts
+++ b/src/main/saveFile.ts
@@ -2,8 +2,13 @@ import { dialog, Event as ElectronEvent, BrowserWindow, ipcMain } from "electron
 import { writeFileSync } from "fs"
 import { isMacOS } from "../common/isMacOS"
 import { heresTheTranscript, thereAreUnsavedChanges } from "../renderer/ipcChannelNames"
+import { setAppState, getAppState } from "../common/appState"
 
 let editorHasUnsavedChanges = false
+
+export interface transcriptState {
+  transcript: string
+}
 
 export const setEditorIsDirty = (unsavedChanges = true) => {
   editorHasUnsavedChanges = unsavedChanges
@@ -28,12 +33,11 @@ export const showSaveDialog: (window: BrowserWindow, transcript: string) => void
   })
 }
 
-export const registerSaveHandler = (window: BrowserWindow) => {
-  ipcMain.on(heresTheTranscript, (event: ElectronEvent, transcript: string) =>
-    showSaveDialog(window, transcript),
-  )
-}
+export const registerSaveHandler = (window: BrowserWindow) => {}
 
-export const listenForWhenTheEditorIsDirty = () => {
-  ipcMain.on(thereAreUnsavedChanges, () => setEditorIsDirty(true))
+export const listenForWhenTheEditorChanges = () => {
+  ipcMain.on(heresTheTranscript, (event: ElectronEvent, transcript: string) => {
+    setAppState({ transcript: transcript })
+    console.log(getAppState())
+  })
 }

--- a/src/main/saveFile.ts
+++ b/src/main/saveFile.ts
@@ -21,8 +21,10 @@ export const showSaveDialog: (window: BrowserWindow, transcript: string) => void
   console.log("showing the save dialog!")
   const appWindow: BrowserWindow | null = isMacOS ? window : null
   dialog.showSaveDialog(appWindow, null, (filepath: string) => {
-    writeFileSync(filepath, transcript, { encoding: "utf-8" })
-    setEditorIsDirty(false)
+    if (filepath) {
+      writeFileSync(filepath, transcript, { encoding: "utf-8" })
+      setEditorIsDirty(false)
+    }
   })
 }
 

--- a/src/main/saveFile.ts
+++ b/src/main/saveFile.ts
@@ -1,8 +1,8 @@
 import { dialog, Event as ElectronEvent, BrowserWindow, ipcMain } from "electron"
 import { writeFileSync } from "fs"
 import { isMacOS } from "../common/isMacOS"
-import { heresTheTranscript, thereAreUnsavedChanges } from "../renderer/ipcChannelNames"
-import { setAppState, getAppState } from "../common/appState"
+import { heresTheTranscript } from "../renderer/ipcChannelNames"
+import { setAppState } from "../common/appState"
 
 let editorHasUnsavedChanges = false
 
@@ -23,7 +23,6 @@ export const showSaveDialog: (window: BrowserWindow, transcript: string) => void
   window: BrowserWindow,
   transcript: string,
 ) => {
-  console.log("showing the save dialog!")
   const appWindow: BrowserWindow | null = isMacOS ? window : null
   dialog.showSaveDialog(appWindow, null, (filepath: string) => {
     if (filepath) {
@@ -38,6 +37,5 @@ export const registerSaveHandler = (window: BrowserWindow) => {}
 export const listenForWhenTheEditorChanges = () => {
   ipcMain.on(heresTheTranscript, (event: ElectronEvent, transcript: string) => {
     setAppState({ transcript: transcript })
-    console.log(getAppState())
   })
 }

--- a/src/renderer/components/editor.tsx
+++ b/src/renderer/components/editor.tsx
@@ -1,4 +1,4 @@
-import { Event as ElectronEvent, ipcRenderer } from "electron"
+import { ipcRenderer } from "electron"
 import Plain from "slate-plain-serializer"
 import { Editor } from "slate-react"
 import { Change, Node as SlateNode, Value } from "slate"
@@ -6,11 +6,8 @@ import { Change, Node as SlateNode, Value } from "slate"
 import Prism from "prismjs"
 import React from "react"
 import PrismMarkdown from "../prism-markdown/prism-markdown.js"
-import {
-  heresTheTranscript,
-  userHasChosenTranscriptFile,
-  userWantsToSaveTranscript,
-} from "../ipcChannelNames"
+import { userHasChosenTranscriptFile, heresTheTranscript } from "../ipcChannelNames"
+import { setAppState } from "../../common/appState"
 
 /**
  * Add the markdown syntax to Prism.
@@ -54,18 +51,11 @@ export class MarkdownPreviewEditor extends React.Component<{}, MarkdownPreviewEd
       this.setState({ value: Plain.deserialize(transcript) })
     })
   }
-  handleSendingTranscript() {
-    ipcRenderer.on(userWantsToSaveTranscript, (event: ElectronEvent) => {
-      event.sender.send(heresTheTranscript, Plain.serialize(this.state.value))
-    })
-  }
   componentDidMount() {
     this.handleLoadingTranscriptFromFile()
-    this.handleSendingTranscript()
   }
   componentWillUnmount() {
     ipcRenderer.removeListener(userHasChosenTranscriptFile, this.handleLoadingTranscriptFromFile)
-    ipcRenderer.removeListener(userWantsToSaveTranscript, this.handleSendingTranscript)
   }
   render() {
     return (
@@ -161,8 +151,8 @@ export class MarkdownPreviewEditor extends React.Component<{}, MarkdownPreviewEd
 
   onChange: (value: Change) => void = ({ value }) => {
     this.setState({ value })
+    setAppState({ transcript: Plain.serialize(value) })
     ipcRenderer.send(heresTheTranscript, Plain.serialize(value))
-    console.log(Plain.serialize(value))
   }
 
   /**

--- a/src/renderer/components/editor.tsx
+++ b/src/renderer/components/editor.tsx
@@ -10,7 +10,6 @@ import {
   heresTheTranscript,
   userHasChosenTranscriptFile,
   userWantsToSaveTranscript,
-  thereAreUnsavedChanges,
 } from "../ipcChannelNames"
 
 /**
@@ -162,7 +161,8 @@ export class MarkdownPreviewEditor extends React.Component<{}, MarkdownPreviewEd
 
   onChange: (value: Change) => void = ({ value }) => {
     this.setState({ value })
-    ipcRenderer.send(thereAreUnsavedChanges)
+    ipcRenderer.send(heresTheTranscript, Plain.serialize(value))
+    console.log(Plain.serialize(value))
   }
 
   /**
@@ -236,7 +236,3 @@ export class MarkdownPreviewEditor extends React.Component<{}, MarkdownPreviewEd
     return decorations
   }
 }
-
-/**
- * Export.
- */

--- a/src/renderer/components/videoContainer.tsx
+++ b/src/renderer/components/videoContainer.tsx
@@ -17,7 +17,9 @@ export class PlayerContainer extends React.Component<{}, PlayerContainerState> {
     this.togglePlayPause = this.togglePlayPause.bind(this)
   }
   public handleSourceChanges(event: Event, pathToMedia: string) {
-    this.setState({ src: pathToMedia })
+    const sourceURL = `file://${pathToMedia}`
+    this.setState({ src: sourceURL })
+    console.log("source is ", this.state.src)
   }
   public componentDidMount() {
     ipcRenderer.on(userHasChosenMediaFile, (event: Event, pathToMedia: string) => {


### PR DESCRIPTION
@colelawrence suggested moving all of this logic into the main process, so that's the plan.

When the transcript changes, the editor sends a message with the transcript's contents. Then, main is free to do what it wants when it comes to a user-initiated save or a save-before closing.

Main always has the latest copy of the transcript, because it's always listening for it. And it never has to involve the browser when trying to figure out if it's safe to close.