### PR TITLE
Use local storage

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+# Version 1.4
+
+## New Features
+
+- Transcriptase now uses localstorage to persist the state of the app. If it unexpectedly quits, you can still relaunch the app and pick up right where you left off.
+
 # Version 1.3.2
 
 ## Major Changes

--- a/src/renderer/components/editorContainer.tsx
+++ b/src/renderer/components/editorContainer.tsx
@@ -30,10 +30,18 @@ export class MarkdownPreviewEditor extends React.Component<{}, MarkdownPreviewEd
   editorRef: RefObject<Editor> = React.createRef()
   constructor(props: any) {
     super(props)
+    const initialTranscriptContents = this.getTranscriptFromLocalStorage() || ""
     this.state = {
-      value: Plain.deserialize(""),
+      value: Plain.deserialize(initialTranscriptContents),
       classNames: "",
     }
+  }
+  writeTranscriptToLocalStorage(transcript: string) {
+    localStorage.setItem("transcript", transcript)
+  }
+
+  getTranscriptFromLocalStorage() {
+    return localStorage.getItem("transcript")
   }
 
   handleLoadingTranscriptFromFile() {
@@ -171,9 +179,11 @@ export class MarkdownPreviewEditor extends React.Component<{}, MarkdownPreviewEd
   }
 
   onChange: (change: Change) => void = change => {
+    const transcript = Plain.serialize(change.value)
     this.setState({ value: change.value })
-    setAppState("transcript", Plain.serialize(change.value))
+    setAppState("transcript", transcript)
     setAppState("safeToQuit", false)
+    this.writeTranscriptToLocalStorage(transcript)
     ipcRenderer.send(heresTheTranscript, Plain.serialize(change.value))
   }
 }

--- a/src/renderer/components/videoContainer.tsx
+++ b/src/renderer/components/videoContainer.tsx
@@ -23,13 +23,15 @@ export class PlayerContainer extends React.Component<{}, PlayerContainerState> {
   mediaPlayer: any
   constructor(props: PlayerContainerProps) {
     super(props)
-    this.state = { src: "", playbackRate: null }
+    const sourceURL = localStorage.getItem("sourceURL") || ""
+    this.state = { src: sourceURL, playbackRate: null }
     this.togglePlayPause = this.togglePlayPause.bind(this)
     this.mediaPlayer = React.createRef<any>()
   }
   public handleSourceChanges(event: Event | DragEvent, pathToMedia: string) {
     const sourceURL = `file://${pathToMedia}`
     this.setState({ src: sourceURL, playbackRate: 1.0 })
+    localStorage.setItem("sourceURL", sourceURL)
   }
   public listenForPlayPauseToggle() {
     ipcRenderer.on(userHasToggledPlayPause, () => {

--- a/src/renderer/components/videoContainer.tsx
+++ b/src/renderer/components/videoContainer.tsx
@@ -1,7 +1,5 @@
 import React, { DragEvent } from "react"
 import { Event as ElectronEvent, ipcRenderer } from "electron"
-// import { PlayerOptions, Source } from "video.js"
-// import { VideoPlayer, PlayerOptions } from "./videojs"
 import {
   userHasChosenMediaFile,
   userHasToggledPlayPause,
@@ -70,12 +68,10 @@ export class PlayerContainer extends React.Component<{}, PlayerContainerState> {
     this.listenForPlayPauseToggle()
     ipcRenderer.on(scrubVideoToTimecodeRenderer, this.handleJumpingInTime)
     this.listenForJumpBackInTime()
-    // this.listenForInsertCurrentTime()
   }
   public componentWillUnmount() {
     ipcRenderer.removeListener(userHasChosenMediaFile, this.handleSourceChanges)
     ipcRenderer.removeListener(scrubVideoToTimecodeRenderer, this.handleJumpingInTime)
-    // ipcRenderer.removeListener(insertCurrentTime, this.listenForInsertCurrentTime)
   }
   public togglePlayPause() {
     if (this.mediaPlayer.current.paused) {
@@ -129,13 +125,5 @@ export class PlayerContainer extends React.Component<{}, PlayerContainerState> {
         </div>
       </ErrorBoundary>
     )
-    // return (
-    //   <div className="wrapper">
-    //     <div className="box a">A</div>
-    //     <div className="box b">B</div>
-    //     <div className="box c">C</div>
-    //     <div className="box d">D</div>
-    //   </div>
-    // )
   }
 }

--- a/src/renderer/components/videoContainer.tsx
+++ b/src/renderer/components/videoContainer.tsx
@@ -24,9 +24,11 @@ export class PlayerContainer extends React.Component<{}, PlayerContainerState> {
   constructor(props: PlayerContainerProps) {
     super(props)
     const sourceURL = localStorage.getItem("sourceURL") || ""
+    const startingTimecode = Number.parseFloat(localStorage.getItem("currentTime")) || 0
     this.state = { src: sourceURL, playbackRate: null }
     this.togglePlayPause = this.togglePlayPause.bind(this)
     this.mediaPlayer = React.createRef<any>()
+    ipcRenderer.send(scrubVideoToTimecodeMain, startingTimecode)
   }
   public handleSourceChanges(event: Event | DragEvent, pathToMedia: string) {
     const sourceURL = `file://${pathToMedia}`
@@ -115,6 +117,7 @@ export class PlayerContainer extends React.Component<{}, PlayerContainerState> {
             src={this.state.src}
             onTimeUpdate={(event: any) => {
               setAppState("currentTime", event.target.currentTime.toString())
+              localStorage.setItem("currentTime", event.target.currentTime.toString())
             }}
             className="media-player"
             id="media-player"


### PR DESCRIPTION
## Major Changes

Persist parts of the app state, so when the user reloads the app it feels more like how they left it. This change includes persisting:

- Transcript contents
- Path to media URL
- Current time (play position)